### PR TITLE
Update xmake.lua to adopt Windows by force toolchain platform set to "mingw"

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -1,6 +1,17 @@
 add_rules("mode.debug", "mode.release")
+add_rules("set_mingw_for_zig_on_windows")
 
 add_requires("zig")
+
+rule("set_mingw_for_zig_on_windows")
+do
+    before_build(function (target)
+        if target:toolchains()[1]:config("zig") and target:toolchains()[1]:config("plat")=="windows" then
+           target:toolchains()[1]:plat_set("mingw")
+        end
+    end)
+end 
+rule_end()
 
 target("zigcc-scaffold")
     set_kind("binary")


### PR DESCRIPTION
Update xmake.lua to adopt Windows by force toolchain platform set to "mingw".
The platform change only affects targets that use `zig` toolchain on Windows.

Add these:
```lua
add_rules("set_mingw_for_zig_on_windows")

rule("set_mingw_for_zig_on_windows")
do
    before_build(function (target)
        if target:toolchains()[1]:config("zig") and target:toolchains()[1]:config("plat")=="windows" then
           target:toolchains()[1]:plat_set("mingw")
        end
    end)
end 
rule_end()
```